### PR TITLE
vorzemplayer improvements

### DIFF
--- a/js.c
+++ b/js.c
@@ -12,6 +12,15 @@
 #include <sys/select.h>
 #include <linux/joystick.h>
 
+static int jsaxis, fwdbtn, revbtn, usefwdbtn;
+
+void setJSParms(int axis, int fbtn, int rbtn, int ufb) {
+	jsaxis=axis;
+	fwdbtn=fbtn;
+	revbtn=rbtn;
+	usefwdbtn=ufb;
+}
+
 int jsOpen(char *devname) {
 	int js;
 	js=open(devname, O_RDONLY|O_NONBLOCK);
@@ -23,39 +32,34 @@ int jsOpen(char *devname) {
 }
 
 void jsRead(int js, int *v1, int *v2) {
-	static int a1=0, a2=0;
+	static int a=0;
 	static int b1=0,b2=0;
-	long v;
+	int v;
 	struct js_event ev;
 	int l;
 	do {
 		l=read(js, &ev, sizeof(ev));
 		if (l==sizeof(ev)) {
 			if (ev.type==JS_EVENT_AXIS) {
-				//printf("js: axis %d val %d\n", ev.number, ev.value);
-				if (ev.number==1) a1=ev.value;
-				if (ev.number==2) a2=ev.value;
+				if (ev.number==jsaxis) a=ev.value;
 			} else if (ev.type==JS_EVENT_BUTTON) {
-				//printf("js: but %d val %d\n", ev.number, ev.value);
-				if (ev.number==1) b1=ev.value;
-				if (ev.number==2) b2=ev.value;
+				if (ev.number==fwdbtn) b1=ev.value;
+				if (ev.number==revbtn) b2=ev.value;
 			}
 		}
 	} while (l==sizeof(ev));
-	if (b1) {
-		v=a1*30000;
-	} else if (b2) {
-		v=-a1*30000;
-	} else {
-		v=a1*a2;
+	v=a;
+	if (b2) {
+		v=-v;
+	} else if (!b1 && usefwdbtn) {
+		v=0;
 	}
-	v=v>>16;
 	if (v<0) {
 		*v1=1;
-		*v2=-((float)v/80);
+		*v2=-v*100/30000;
 	} else {
 		*v1=0;
-		*v2=((float)v/80);
+		*v2=v*100/30000;
 	}
 	if (*v2>100) *v2=100;
 }

--- a/js.c
+++ b/js.c
@@ -32,11 +32,11 @@ void jsRead(int js, int *v1, int *v2) {
 		l=read(js, &ev, sizeof(ev));
 		if (l==sizeof(ev)) {
 			if (ev.type==JS_EVENT_AXIS) {
-				printf("js: axis %d val %d\n", ev.number, ev.value);
+				//printf("js: axis %d val %d\n", ev.number, ev.value);
 				if (ev.number==1) a1=ev.value;
 				if (ev.number==2) a2=ev.value;
 			} else if (ev.type==JS_EVENT_BUTTON) {
-				printf("js: but %d val %d\n", ev.number, ev.value);
+				//printf("js: but %d val %d\n", ev.number, ev.value);
 				if (ev.number==1) b1=ev.value;
 				if (ev.number==2) b2=ev.value;
 			}

--- a/js.h
+++ b/js.h
@@ -1,6 +1,7 @@
 #ifndef JS_H
 #define JS_H
 
+void setJSParms(int jsaxis, int fwdbtn, int revbtn, int usefwdbtn);
 int jsOpen(char *devname);
 void jsRead(int js, int *v1, int *v2);
 void jsClose(int js);

--- a/main.c
+++ b/main.c
@@ -92,8 +92,9 @@ int main(int argc, char **argv) {
 		handleTs(0, csv, vorze);
 		while(ts>=0) {
 			ts=mplayerUdpGetTimestamp(sock)+offset;
+			printf("\rFrame: %5d  ", ts);
+                        fflush(stdout);
 			handleTs(ts, csv, vorze);
-			printf("Frame: %d\n", ts);
 		}
 		mplayerUdpClose(sock);
 		csvFree(csv);

--- a/main.c
+++ b/main.c
@@ -41,6 +41,7 @@ int main(int argc, char **argv) {
 	int sock;
 	int port=23867;
 	int vorze;
+	int controlvorze=1;
 	int offset=0;
 	int ts=0;
 	int action=ACT_NONE;
@@ -61,6 +62,8 @@ int main(int argc, char **argv) {
 		} else if (!strcmp(argv[ix], "-o") && ix<argc-1) {
 			ix++;
 			offset=atoi(argv[ix]);
+		} else if (!strcmp(argv[ix], "-n") && ix<argc-1) {
+			controlvorze=0;
 		} else if (!strcmp(argv[ix], "play") && ix<argc-1) {
 			action=ACT_PLAY;
 			ix++;
@@ -93,12 +96,15 @@ int main(int argc, char **argv) {
 		printf(" %s test [options]\n", argv[0]);
 		printf(" %s playsa file.csv [options]\n", argv[0]);
 		printf(" %s recordsa file.csv [options]\n", argv[0]);
+		printf(" -n: don't control Vorze (def: do control)\n");
 		printf(" -c serport: specify Vorze serial port (def: autodetect)\n");
 		printf(" -u udpport: specify mplayer UDP port (def: 23867)\n");
 		printf(" -o 1234: specify movie offset in decisec (def: 0)\n");
 		exit(0);
 	}
 	
+	if (!controlvorze) enableSimulation();
+
 	if (strlen(serport)==0) vorzeDetectPort(serport);
 
 	vorze=vorzeOpen(serport);

--- a/main.c
+++ b/main.c
@@ -2,9 +2,11 @@
 #include "csv.h"
 #include "vorze.h"
 #include "js.h"
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/time.h>
 
 void handleTs(int ts, CsvEntry *csv, int vorzeHandle) {
 	static char currV1=-1, currV2=-1;
@@ -20,6 +22,15 @@ void handleTs(int ts, CsvEntry *csv, int vorzeHandle) {
 #define ACT_PLAY 1
 #define ACT_RECORD 2
 #define ACT_TEST 3
+#define ACT_PLAYSA 4
+#define ACT_RECORDSA 5
+
+volatile sig_atomic_t gotalarm=0;
+
+void handle_alarm(int signum) {
+	gotalarm=1;
+	signal(SIGALRM, handle_alarm);
+}
 
 int main(int argc, char **argv) {
 	CsvEntry *csv, *ent;
@@ -60,6 +71,14 @@ int main(int argc, char **argv) {
 			strcpy(csvfile, argv[ix]);
 		} else if (!strcmp(argv[ix], "test")) {
 			action=ACT_TEST;
+		} else if (!strcmp(argv[ix], "playsa") && ix<argc-1) {
+			action=ACT_PLAYSA;
+			ix++;
+			strcpy(csvfile, argv[ix]);
+		} else if (!strcmp(argv[ix], "recordsa") && ix<argc-1) {
+			action=ACT_RECORDSA;
+			ix++;
+			strcpy(csvfile, argv[ix]);
 		} else {
 			action=ACT_NONE;
 			printf("Error: Unknown arg %s\n", argv[ix]);
@@ -72,6 +91,8 @@ int main(int argc, char **argv) {
 		printf(" %s play file.csv [options]\n", argv[0]);
 		printf(" %s record file.csv [options]\n", argv[0]);
 		printf(" %s test [options]\n", argv[0]);
+		printf(" %s playsa file.csv [options]\n", argv[0]);
+		printf(" %s recordsa file.csv [options]\n", argv[0]);
 		printf(" -c serport: specify Vorze serial port (def: autodetect)\n");
 		printf(" -u udpport: specify mplayer UDP port (def: 23867)\n");
 		printf(" -o 1234: specify movie offset in decisec (def: 0)\n");
@@ -141,6 +162,77 @@ int main(int argc, char **argv) {
 			}
 			usleep(100000);
 		}
+		jsClose(js);
+	}
+
+	if (action==ACT_PLAYSA) {
+		csv=csvLoad(csvfile);
+		if (csv==NULL) exit(1);
+		sigset_t mask, oldmask;
+		sigemptyset(&mask);
+		sigaddset(&mask, SIGALRM);
+		sigprocmask(SIG_BLOCK, &mask, &oldmask);
+		signal(SIGALRM, handle_alarm);
+		const struct itimerval TENTHS = {{0, 100000}, {0, 100000}};
+		if (setitimer(ITIMER_REAL, &TENTHS, NULL)) {
+			exit(1);
+		}
+
+		handleTs(0, csv, vorze);
+		while(ts>=0) {
+			while(!gotalarm) {
+				sigsuspend(&oldmask);
+			}
+			gotalarm = 0;
+			sigprocmask(SIG_UNBLOCK, &mask, NULL);
+			printf("\rFrame: %5d  ", ts);
+                        fflush(stdout);
+			handleTs(ts, csv, vorze);
+                        ts++;
+		}
+		csvFree(csv);
+	}
+
+	if (action==ACT_RECORDSA) {
+		int v1, v2;
+		int oldv1=-1, oldv2=-1;
+		FILE *f;
+		js=jsOpen(jsdev);
+		f=fopen(csvfile, "w");
+		if (f==NULL) {
+			perror(csvfile);
+			exit(1);
+		}
+		sigset_t mask, oldmask;
+		sigemptyset(&mask);
+		sigaddset(&mask, SIGALRM);
+		sigprocmask(SIG_BLOCK, &mask, &oldmask);
+		signal(SIGALRM, handle_alarm);
+		const struct itimerval TENTHS = {{0, 100000}, {0, 100000}};
+		if (setitimer(ITIMER_REAL, &TENTHS, NULL)) {
+			exit(1);
+		}
+
+		while(ts>=0) {
+			while(!gotalarm) {
+				sigsuspend(&oldmask);
+			}
+			gotalarm = 0;
+			sigprocmask(SIG_UNBLOCK, &mask, NULL);
+			jsRead(js, &v1, &v2);
+			printf("\rFrame: %5d  ", ts);
+			fflush(stdout);
+			if (v1!=oldv1 || v2!=oldv2) {
+				vorzeSet(vorze, v1, v2);
+				oldv1=v1; oldv2=v2;
+				fprintf(f, "%d,%d,%d\n", ts, v1, v2);
+				fflush(f);
+			} else {
+				vorzeDoResendIfNeeded(vorze);
+			}
+			ts++;
+		}
+		fclose(f);
 		jsClose(js);
 	}
 }

--- a/main.c
+++ b/main.c
@@ -145,7 +145,7 @@ int main(int argc, char **argv) {
 		while(ts>=0) {
 			ts=mplayerUdpGetTimestamp(sock)+offset;
 			printf("\rFrame: %5d  ", ts);
-                        fflush(stdout);
+			fflush(stdout);
 			handleTs(ts, csv, vorze);
 		}
 		mplayerUdpClose(sock);
@@ -168,6 +168,7 @@ int main(int argc, char **argv) {
 			ts=mplayerUdpGetTimestamp(sock)+offset;
 			printf("\rFrame: %5d  ", ts);
 			jsRead(js, &v1, &v2);
+			fflush(stdout);
 			if (v1!=oldv1 || v2!=oldv2) {
 				vorzeSet(vorze, v1, v2);
 				oldv1=v1; oldv2=v2;
@@ -218,9 +219,9 @@ int main(int argc, char **argv) {
 			gotalarm = 0;
 			sigprocmask(SIG_UNBLOCK, &mask, NULL);
 			printf("\rFrame: %5d  ", ts);
-                        fflush(stdout);
+			fflush(stdout);
 			handleTs(ts, csv, vorze);
-                        ts++;
+			ts++;
 		}
 		csvFree(csv);
 	}

--- a/vorze.c
+++ b/vorze.c
@@ -222,15 +222,11 @@ int vorzeSet(int handle, int v1, int v2) {
 
 int vorzeClose(int handle) {
 	if (!simulate) {
-		printf("\nAttempting to stop Vorze.");
-		fflush(stdout);
+		printf("\nAttempting to stop Vorze...\n");
 		vorzeSet(handle, 0, 0);
 		usleep(250000);
-		printf(".");
-		fflush(stdout);
 		vorzeSet(handle, 0, 0);
 		usleep(250000);
-		printf(".\n");
 		vorzeSet(handle, 0, 0);
 	}
 	close(handle);

--- a/vorze.c
+++ b/vorze.c
@@ -221,7 +221,17 @@ int vorzeSet(int handle, int v1, int v2) {
 }
 
 int vorzeClose(int handle) {
-	vorzeSet(handle, 0, 0);
-	if (!simulate) close(handle);
-	return;
+	if (!simulate) {
+		printf("\nAttempting to stop Vorze.");
+		fflush(stdout);
+		vorzeSet(handle, 0, 0);
+		usleep(250000);
+		printf(".");
+		fflush(stdout);
+		vorzeSet(handle, 0, 0);
+		usleep(250000);
+		printf(".\n");
+		vorzeSet(handle, 0, 0);
+	}
+	close(handle);
 }

--- a/vorze.c
+++ b/vorze.c
@@ -194,7 +194,7 @@ int vorzeSet(int handle, int v1, int v2) {
 		clock_gettime(CLOCK_MONOTONIC, &slots[i].ts);
 		buff[2]=(v1?0x80:0)|v2;
 		write(handle, buff, 3);
-		printf("V1=%d V2=%d (slot %d)\n", v1, v2, i);
+		printf("V1=%d V2=%3d (slot %d)\n", v1, v2, i);
 		needResend=0;
 	} else {
 		//We need to send this Later.

--- a/vorze.c
+++ b/vorze.c
@@ -95,9 +95,17 @@ int vorzeDetectPort(char *serport) {
 	return found;
 }
 
+//Don't actually send anything to Vorze; just write console output
+static int simulate=0;
+
+void enableSimulation() {
+	simulate=1;
+}
 
 //Open the serial port to the Vorze.
 int vorzeOpen(char *port) {
+	if (simulate) return 255;
+
 	struct termios newtio;
 	fd_set rfds;
 	struct timeval tv;
@@ -162,6 +170,8 @@ static void handleSlots() {
 }
 
 int vorzeDoResendIfNeeded(int handle) {
+	if (simulate) return;
+
 	int i, canSend=0;
 	handleSlots();
 	if (!needResend) return;
@@ -178,6 +188,13 @@ int vorzeDoResendIfNeeded(int handle) {
 }
 
 int vorzeSet(int handle, int v1, int v2) {
+	const char fmtstr[] = "V1=%d V2=%3d (slot %d)\n";
+
+	if (simulate) {
+		printf(fmtstr, v1, v2, 0);
+		return;
+	}
+
 	int i;
 	int canSend=0;
 	char buff[3]={1,1,0};
@@ -194,7 +211,7 @@ int vorzeSet(int handle, int v1, int v2) {
 		clock_gettime(CLOCK_MONOTONIC, &slots[i].ts);
 		buff[2]=(v1?0x80:0)|v2;
 		write(handle, buff, 3);
-		printf("V1=%d V2=%3d (slot %d)\n", v1, v2, i);
+		printf(fmtstr, v1, v2, i);
 		needResend=0;
 	} else {
 		//We need to send this Later.
@@ -205,6 +222,6 @@ int vorzeSet(int handle, int v1, int v2) {
 
 int vorzeClose(int handle) {
 	vorzeSet(handle, 0, 0);
-	close(handle);
+	if (!simulate) close(handle);
 	return;
 }

--- a/vorze.c
+++ b/vorze.c
@@ -91,7 +91,7 @@ int vorzeDetectPort(char *serport) {
 		globfree(&globbuf2);
 	}
 	globfree(&globbuf);
-	if (!found) printf("No Forze USB stick found.\n");
+	if (!found) printf("No Vorze USB stick found.\n");
 	return found;
 }
 

--- a/vorze.h
+++ b/vorze.h
@@ -1,6 +1,7 @@
 #ifndef VORZE_H
 #define VORZE_H
 
+void enableSimulation();
 int vorzeOpen(char *port);
 int vorzeSet(int handle, int v1, int v2);
 int vorzeClose(int handle);


### PR DESCRIPTION
Enhanced and cleaned up the application a bit
- Stopped it from spamming the console. No more messages about every single joystick event, and the frame counter now stays on one line until a Vorze control change. One can now much more easily see what happens when.
- Made joystick axis and buttons configurable. Reduced to one axis. Now any Linux compatible joystick device with at least a _single_ analog axis and maybe a button or two should be useable, regardless of how its mapped.
- Added switch to turn off Vorze output, for testing or other purposes.
- Added commands "playsa" and "recordsa" ("sa" = "stand-alone"), which work like "play" and "record", but don't sync to mplayer. Instead, they use their own timing. Currently, there's no way to seek, you just have to play from beginning and let it go. It also doesn't stop the Vorze if you Ctrl-C it, so that's something to be added.
