### PR TITLE
vorzemplayer enhancements (take 2)

### DIFF
--- a/js.c
+++ b/js.c
@@ -12,6 +12,15 @@
 #include <sys/select.h>
 #include <linux/joystick.h>
 
+static int jsaxis, fwdbtn, revbtn, usefwdbtn;
+
+void setJSParms(int axis, int fbtn, int rbtn, int ufb) {
+	jsaxis=axis;
+	fwdbtn=fbtn;
+	revbtn=rbtn;
+	usefwdbtn=ufb;
+}
+
 int jsOpen(char *devname) {
 	int js;
 	js=open(devname, O_RDONLY|O_NONBLOCK);
@@ -23,39 +32,34 @@ int jsOpen(char *devname) {
 }
 
 void jsRead(int js, int *v1, int *v2) {
-	static int a1=0, a2=0;
+	static int a=0;
 	static int b1=0,b2=0;
-	long v;
+	int v;
 	struct js_event ev;
 	int l;
 	do {
 		l=read(js, &ev, sizeof(ev));
 		if (l==sizeof(ev)) {
 			if (ev.type==JS_EVENT_AXIS) {
-				//printf("js: axis %d val %d\n", ev.number, ev.value);
-				if (ev.number==1) a1=ev.value;
-				if (ev.number==2) a2=ev.value;
+				if (ev.number==jsaxis) a=ev.value;
 			} else if (ev.type==JS_EVENT_BUTTON) {
-				//printf("js: but %d val %d\n", ev.number, ev.value);
-				if (ev.number==1) b1=ev.value;
-				if (ev.number==2) b2=ev.value;
+				if (ev.number==fwdbtn) b1=ev.value;
+				if (ev.number==revbtn) b2=ev.value;
 			}
 		}
 	} while (l==sizeof(ev));
-	if (b1) {
-		v=a1*30000;
-	} else if (b2) {
-		v=-a1*30000;
-	} else {
-		v=a1*a2;
+	v=a;
+	if (b2) {
+		v=-v;
+	} else if (!b1 && usefwdbtn) {
+		v=0;
 	}
-	v=v>>16;
 	if (v<0) {
 		*v1=1;
-		*v2=-((float)v/80);
+		*v2=-v*100/30000;
 	} else {
 		*v1=0;
-		*v2=((float)v/80);
+		*v2=v*100/30000;
 	}
 	if (*v2>100) *v2=100;
 }

--- a/js.c
+++ b/js.c
@@ -32,11 +32,11 @@ void jsRead(int js, int *v1, int *v2) {
 		l=read(js, &ev, sizeof(ev));
 		if (l==sizeof(ev)) {
 			if (ev.type==JS_EVENT_AXIS) {
-				printf("js: axis %d val %d\n", ev.number, ev.value);
+				//printf("js: axis %d val %d\n", ev.number, ev.value);
 				if (ev.number==1) a1=ev.value;
 				if (ev.number==2) a2=ev.value;
 			} else if (ev.type==JS_EVENT_BUTTON) {
-				printf("js: but %d val %d\n", ev.number, ev.value);
+				//printf("js: but %d val %d\n", ev.number, ev.value);
 				if (ev.number==1) b1=ev.value;
 				if (ev.number==2) b2=ev.value;
 			}

--- a/js.h
+++ b/js.h
@@ -1,6 +1,7 @@
 #ifndef JS_H
 #define JS_H
 
+void setJSParms(int jsaxis, int fwdbtn, int revbtn, int usefwdbtn);
 int jsOpen(char *devname);
 void jsRead(int js, int *v1, int *v2);
 void jsClose(int js);

--- a/main.c
+++ b/main.c
@@ -92,8 +92,9 @@ int main(int argc, char **argv) {
 		handleTs(0, csv, vorze);
 		while(ts>=0) {
 			ts=mplayerUdpGetTimestamp(sock)+offset;
+			printf("\rFrame: %5d  ", ts);
+                        fflush(stdout);
 			handleTs(ts, csv, vorze);
-			printf("Frame: %d\n", ts);
 		}
 		mplayerUdpClose(sock);
 		csvFree(csv);

--- a/main.c
+++ b/main.c
@@ -41,6 +41,7 @@ int main(int argc, char **argv) {
 	int sock;
 	int port=23867;
 	int vorze;
+	int controlvorze=1;
 	int offset=0;
 	int ts=0;
 	int action=ACT_NONE;
@@ -61,6 +62,8 @@ int main(int argc, char **argv) {
 		} else if (!strcmp(argv[ix], "-o") && ix<argc-1) {
 			ix++;
 			offset=atoi(argv[ix]);
+		} else if (!strcmp(argv[ix], "-n") && ix<argc-1) {
+			controlvorze=0;
 		} else if (!strcmp(argv[ix], "play") && ix<argc-1) {
 			action=ACT_PLAY;
 			ix++;
@@ -93,12 +96,15 @@ int main(int argc, char **argv) {
 		printf(" %s test [options]\n", argv[0]);
 		printf(" %s playsa file.csv [options]\n", argv[0]);
 		printf(" %s recordsa file.csv [options]\n", argv[0]);
+		printf(" -n: don't control Vorze (def: do control)\n");
 		printf(" -c serport: specify Vorze serial port (def: autodetect)\n");
 		printf(" -u udpport: specify mplayer UDP port (def: 23867)\n");
 		printf(" -o 1234: specify movie offset in decisec (def: 0)\n");
 		exit(0);
 	}
 	
+	if (!controlvorze) enableSimulation();
+
 	if (strlen(serport)==0) vorzeDetectPort(serport);
 
 	vorze=vorzeOpen(serport);

--- a/main.c
+++ b/main.c
@@ -2,9 +2,11 @@
 #include "csv.h"
 #include "vorze.h"
 #include "js.h"
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/time.h>
 
 void handleTs(int ts, CsvEntry *csv, int vorzeHandle) {
 	static char currV1=-1, currV2=-1;
@@ -20,6 +22,15 @@ void handleTs(int ts, CsvEntry *csv, int vorzeHandle) {
 #define ACT_PLAY 1
 #define ACT_RECORD 2
 #define ACT_TEST 3
+#define ACT_PLAYSA 4
+#define ACT_RECORDSA 5
+
+volatile sig_atomic_t gotalarm=0;
+
+void handle_alarm(int signum) {
+	gotalarm=1;
+	signal(SIGALRM, handle_alarm);
+}
 
 int main(int argc, char **argv) {
 	CsvEntry *csv, *ent;
@@ -60,6 +71,14 @@ int main(int argc, char **argv) {
 			strcpy(csvfile, argv[ix]);
 		} else if (!strcmp(argv[ix], "test")) {
 			action=ACT_TEST;
+		} else if (!strcmp(argv[ix], "playsa") && ix<argc-1) {
+			action=ACT_PLAYSA;
+			ix++;
+			strcpy(csvfile, argv[ix]);
+		} else if (!strcmp(argv[ix], "recordsa") && ix<argc-1) {
+			action=ACT_RECORDSA;
+			ix++;
+			strcpy(csvfile, argv[ix]);
 		} else {
 			action=ACT_NONE;
 			printf("Error: Unknown arg %s\n", argv[ix]);
@@ -72,6 +91,8 @@ int main(int argc, char **argv) {
 		printf(" %s play file.csv [options]\n", argv[0]);
 		printf(" %s record file.csv [options]\n", argv[0]);
 		printf(" %s test [options]\n", argv[0]);
+		printf(" %s playsa file.csv [options]\n", argv[0]);
+		printf(" %s recordsa file.csv [options]\n", argv[0]);
 		printf(" -c serport: specify Vorze serial port (def: autodetect)\n");
 		printf(" -u udpport: specify mplayer UDP port (def: 23867)\n");
 		printf(" -o 1234: specify movie offset in decisec (def: 0)\n");
@@ -141,6 +162,77 @@ int main(int argc, char **argv) {
 			}
 			usleep(100000);
 		}
+		jsClose(js);
+	}
+
+	if (action==ACT_PLAYSA) {
+		csv=csvLoad(csvfile);
+		if (csv==NULL) exit(1);
+		sigset_t mask, oldmask;
+		sigemptyset(&mask);
+		sigaddset(&mask, SIGALRM);
+		sigprocmask(SIG_BLOCK, &mask, &oldmask);
+		signal(SIGALRM, handle_alarm);
+		const struct itimerval TENTHS = {{0, 100000}, {0, 100000}};
+		if (setitimer(ITIMER_REAL, &TENTHS, NULL)) {
+			exit(1);
+		}
+
+		handleTs(0, csv, vorze);
+		while(ts>=0) {
+			while(!gotalarm) {
+				sigsuspend(&oldmask);
+			}
+			gotalarm = 0;
+			sigprocmask(SIG_UNBLOCK, &mask, NULL);
+			printf("\rFrame: %5d  ", ts);
+                        fflush(stdout);
+			handleTs(ts, csv, vorze);
+                        ts++;
+		}
+		csvFree(csv);
+	}
+
+	if (action==ACT_RECORDSA) {
+		int v1, v2;
+		int oldv1=-1, oldv2=-1;
+		FILE *f;
+		js=jsOpen(jsdev);
+		f=fopen(csvfile, "w");
+		if (f==NULL) {
+			perror(csvfile);
+			exit(1);
+		}
+		sigset_t mask, oldmask;
+		sigemptyset(&mask);
+		sigaddset(&mask, SIGALRM);
+		sigprocmask(SIG_BLOCK, &mask, &oldmask);
+		signal(SIGALRM, handle_alarm);
+		const struct itimerval TENTHS = {{0, 100000}, {0, 100000}};
+		if (setitimer(ITIMER_REAL, &TENTHS, NULL)) {
+			exit(1);
+		}
+
+		while(ts>=0) {
+			while(!gotalarm) {
+				sigsuspend(&oldmask);
+			}
+			gotalarm = 0;
+			sigprocmask(SIG_UNBLOCK, &mask, NULL);
+			jsRead(js, &v1, &v2);
+			printf("\rFrame: %5d  ", ts);
+			fflush(stdout);
+			if (v1!=oldv1 || v2!=oldv2) {
+				vorzeSet(vorze, v1, v2);
+				oldv1=v1; oldv2=v2;
+				fprintf(f, "%d,%d,%d\n", ts, v1, v2);
+				fflush(f);
+			} else {
+				vorzeDoResendIfNeeded(vorze);
+			}
+			ts++;
+		}
+		fclose(f);
 		jsClose(js);
 	}
 }

--- a/main.c
+++ b/main.c
@@ -145,7 +145,7 @@ int main(int argc, char **argv) {
 		while(ts>=0) {
 			ts=mplayerUdpGetTimestamp(sock)+offset;
 			printf("\rFrame: %5d  ", ts);
-                        fflush(stdout);
+			fflush(stdout);
 			handleTs(ts, csv, vorze);
 		}
 		mplayerUdpClose(sock);
@@ -168,6 +168,7 @@ int main(int argc, char **argv) {
 			ts=mplayerUdpGetTimestamp(sock)+offset;
 			printf("\rFrame: %5d  ", ts);
 			jsRead(js, &v1, &v2);
+			fflush(stdout);
 			if (v1!=oldv1 || v2!=oldv2) {
 				vorzeSet(vorze, v1, v2);
 				oldv1=v1; oldv2=v2;
@@ -218,9 +219,9 @@ int main(int argc, char **argv) {
 			gotalarm = 0;
 			sigprocmask(SIG_UNBLOCK, &mask, NULL);
 			printf("\rFrame: %5d  ", ts);
-                        fflush(stdout);
+			fflush(stdout);
 			handleTs(ts, csv, vorze);
-                        ts++;
+			ts++;
 		}
 		csvFree(csv);
 	}

--- a/mplayer2-patches/0001-Porting-udp_sync-from-MPlayer-1.patch
+++ b/mplayer2-patches/0001-Porting-udp_sync-from-MPlayer-1.patch
@@ -1,0 +1,426 @@
+From 10957cf8ae1b12879feb8c41bf420822b146ebf7 Mon Sep 17 00:00:00 2001
+From: Crewmen <crewmen@sigaint.org>
+Date: Mon, 26 May 2015 00:18:02 +0000
+Subject: [PATCH 1/2] Porting udp_sync from MPlayer 1.
+
+---
+ Makefile      |   1 +
+ cfg-mplayer.h |  10 +++
+ mplayer.c     |  32 ++++++++
+ udp_sync.c    | 246 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ udp_sync.h    |  38 +++++++++
+ 5 files changed, 327 insertions(+)
+ create mode 100644 udp_sync.c
+ create mode 100644 udp_sync.h
+
+diff --git a/Makefile b/Makefile
+index 56d50f7..d2202a9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -120,6 +120,7 @@ SRCS_COMMON-$(NETWORKING)            += stream/asf_mmst_streaming.c \
+                                         stream/tcp.c \
+                                         stream/stream_rtp.c \
+                                         stream/stream_udp.c \
++                                        udp_sync.c \
+ 
+ SRCS_COMMON-$(PNG)                   += libmpcodecs/vd_mpng.c
+ SRCS_COMMON-$(PRIORITY)              += osdep/priority.c
+diff --git a/cfg-mplayer.h b/cfg-mplayer.h
+index ff8868f..7b611e4 100644
+--- a/cfg-mplayer.h
++++ b/cfg-mplayer.h
+@@ -432,12 +432,22 @@ const m_option_t common_opts[] = {
+ #else
+     {"prefer-ipv6", "MPlayer was compiled without IPv6 support.\n", CONF_TYPE_PRINT, 0, 0, 0, NULL},
+ #endif /* HAVE_AF_INET6 */
++    {"udp-slave", &udp_slave, CONF_TYPE_FLAG, 0, 0, 1, NULL},
++    {"udp-master", &udp_master, CONF_TYPE_FLAG, 0, 0, 1, NULL},
++    {"udp-ip", &udp_ip, CONF_TYPE_STRING, 0, 0, 1, NULL},
++    {"udp-port", &udp_port, CONF_TYPE_INT, 0, 1, 65535, NULL},
++    {"udp-seek-threshold", &udp_seek_threshold, CONF_TYPE_FLOAT, CONF_RANGE, 0.1, 100, NULL},
+ 
+ #else
+     {"user", "MPlayer was compiled without streaming (network) support.\n", CONF_TYPE_PRINT, CONF_NOCFG, 0, 0, NULL},
+     {"passwd", "MPlayer was compiled without streaming (network) support.\n", CONF_TYPE_PRINT, CONF_NOCFG, 0, 0, NULL},
+     {"bandwidth", "MPlayer was compiled without streaming (network) support.\n", CONF_TYPE_PRINT, CONF_NOCFG, 0, 0, NULL},
+     {"user-agent", "MPlayer was compiled without streaming (network) support.\n", CONF_TYPE_PRINT, CONF_NOCFG, 0, 0, NULL},
++    {"udp-slave", "MPlayer was compiled without streaming (network) support.\n", CONF_TYPE_PRINT, CONF_NOCFG, 0, 0, NULL},
++    {"udp-master", "MPlayer was compiled without streaming (network) support.\n", CONF_TYPE_PRINT, CONF_NOCFG, 0, 0, NULL},
++    {"udp-ip", "MPlayer was compiled without streaming (network) support.\n", CONF_TYPE_PRINT, CONF_NOCFG, 0, 0, NULL},
++    {"udp-port", "MPlayer was compiled without streaming (network) support.\n", CONF_TYPE_PRINT, CONF_NOCFG, 0, 0, NULL},
++    {"udp-seek-threshold", "MPlayer was compiled without streaming (network) support.\n", CONF_TYPE_PRINT, CONF_NOCFG, 0, 0, NULL},
+ #endif /* CONFIG_NETWORKING */
+ 
+ 
+diff --git a/mplayer.c b/mplayer.c
+index dab8535..14ac794 100644
+--- a/mplayer.c
++++ b/mplayer.c
+@@ -94,6 +94,8 @@
+ #include "cpudetect.h"
+ #include "version.h"
+ 
++#include "udp_sync.h"
++
+ #ifdef CONFIG_X11
+ #include "libvo/x11_common.h"
+ #endif
+@@ -669,6 +671,11 @@ void uninit_player(struct MPContext *mpctx, unsigned int mask)
+ 
+ void exit_player_with_rc(struct MPContext *mpctx, enum exit_reason how, int rc)
+ {
++#ifdef CONFIG_NETWORKING
++    if (udp_master)
++        send_udp(mpctx, udp_ip, udp_port, "bye");
++#endif /* CONFIG_NETWORKING */
++
+     uninit_player(mpctx, INITIALIZED_ALL);
+ #if defined(__MINGW32__) || defined(__CYGWIN__)
+     timeEndPeriod(1);
+@@ -2583,6 +2590,17 @@ static int fill_audio_out_buffers(struct MPContext *mpctx, double endpts)
+     return -partial_fill;
+ }
+ 
++static void handle_udp_master(struct MPContext *mpctx)
++{
++#ifdef CONFIG_NETWORKING
++    if (udp_master) {
++        char current_time[256];
++        snprintf(current_time, sizeof(current_time), "%f", mpctx->sh_video->pts);
++        send_udp(mpctx, udp_ip, udp_port, current_time);
++    }
++#endif /* CONFIG_NETWORKING */
++}
++
+ int reinit_video_chain(struct MPContext *mpctx)
+ {
+     struct MPOpts *opts = &mpctx->opts;
+@@ -3471,6 +3489,17 @@ static void run_playloop(struct MPContext *mpctx)
+             }
+         }
+ 
++#ifdef CONFIG_NETWORKING
++        if (udp_slave) {
++            int udp_master_exited = udp_slave_sync(mpctx);
++            if (udp_master_exited > 0) {
++                mp_msg(MSGT_CPLAYER, MSGL_INFO, "Option -udp-slave: exiting because master exited\n");
++                exit_player(mpctx, EXIT_QUIT);
++            } else if (udp_master_exited == 0)
++                goto flip_page;
++        }
++#endif /* CONFIG_NETWORKING */
++
+         if (!video_left || (mpctx->paused && !mpctx->restart_playback))
+             break;
+         if (!vo->frame_loaded) {
+@@ -3518,8 +3547,11 @@ static void run_playloop(struct MPContext *mpctx)
+         }
+         sleeptime = 0;
+ 
++        handle_udp_master(mpctx);
++
+         //=================== FLIP PAGE (VIDEO BLT): ======================
+ 
++        flip_page:
+         current_module = "flip_page";
+         vo_new_frame_imminent(vo);
+         struct sh_video *sh_video = mpctx->sh_video;
+diff --git a/udp_sync.c b/udp_sync.c
+new file mode 100644
+index 0000000..0c4a518
+--- /dev/null
++++ b/udp_sync.c
+@@ -0,0 +1,246 @@
++/*
++ * Network playback synchronization
++ * Copyright (C) 2009 Google Inc.
++ *
++ * This file is part of MPlayer.
++ *
++ * MPlayer is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * MPlayer is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License along
++ * with MPlayer; if not, write to the Free Software Foundation, Inc.,
++ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
++ */
++
++#define _BSD_SOURCE
++
++#include "config.h"
++
++#if !HAVE_WINSOCK2_H
++#include <errno.h>
++#include <sys/types.h>
++#include <sys/socket.h>
++#include <netinet/in.h>
++#include <arpa/inet.h>
++#include <stdlib.h>
++#include <sys/ioctl.h>
++#include <fcntl.h>
++#include <string.h>
++#include <strings.h>
++#include <netdb.h>
++#include <signal.h>
++#else
++#include <winsock2.h>
++#include <ws2tcpip.h>
++#endif /* HAVE_WINSOCK2_H */
++
++#include "mplayer.h"
++#include "mp_core.h"
++#include "libmpdemux/stheader.h"
++#include "mp_msg.h"
++#include "udp_sync.h"
++#include "osdep/timer.h"
++#include "libavutil/common.h"
++
++
++// config options for UDP sync
++int udp_master = 0;
++int udp_slave  = 0;
++int udp_port   = 23867;
++const char *udp_ip = "127.0.0.1"; // where the master sends datagrams
++                                  // (can be a broadcast address)
++float udp_seek_threshold = 1.0;   // how far off before we seek
++
++// how far off is still considered equal
++#define UDP_TIMING_TOLERANCE 0.02
++
++static void startup(void)
++{
++#if HAVE_WINSOCK2_H
++    static int wsa_started;
++    if (!wsa_started) {
++        WSADATA wd;
++        WSAStartup(0x0202, &wd);
++        wsa_started = 1;
++    }
++#endif
++}
++
++static void set_blocking(int fd, int blocking)
++{
++    long sock_flags;
++#if HAVE_WINSOCK2_H
++    sock_flags = !blocking;
++    ioctlsocket(fd, FIONBIO, &sock_flags);
++#else
++    sock_flags = fcntl(fd, F_GETFL, 0);
++    sock_flags = blocking ? sock_flags & ~O_NONBLOCK : sock_flags | O_NONBLOCK;
++    fcntl(fd, F_SETFL, sock_flags);
++#endif /* HAVE_WINSOCK2_H */
++}
++
++// gets a datagram from the master with or without blocking.  updates
++// master_position if successful.  if the master has exited, returns 1.
++// returns -1 on error or if no message received.
++// otherwise, returns 0.
++static int get_udp(int blocking, double *master_position)
++{
++    char mesg[100];
++
++    int chars_received = -1;
++    int n;
++
++    static int sockfd = -1;
++    if (sockfd == -1) {
++#if HAVE_WINSOCK2_H
++        DWORD tv = 30000;
++#else
++        struct timeval tv = { .tv_sec = 30 };
++#endif
++        struct sockaddr_in servaddr = { 0 };
++
++        startup();
++        sockfd = socket(AF_INET, SOCK_DGRAM, 0);
++        if (sockfd == -1)
++            return -1;
++
++        servaddr.sin_family      = AF_INET;
++        servaddr.sin_addr.s_addr = htonl(INADDR_ANY);
++        servaddr.sin_port        = htons(udp_port);
++        bind(sockfd, (struct sockaddr *)&servaddr, sizeof(servaddr));
++
++        setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
++
++    }
++
++    set_blocking(sockfd, blocking);
++
++    while (-1 != (n = recvfrom(sockfd, mesg, sizeof(mesg)-1, 0,
++                               NULL, NULL))) {
++        char *end;
++        // flush out any further messages so we don't get behind
++        if (chars_received == -1)
++            set_blocking(sockfd, 0);
++
++        chars_received = n;
++        mesg[chars_received] = 0;
++        if (strcmp(mesg, "bye") == 0)
++            return 1;
++        *master_position = strtod(mesg, &end);
++        if (*end) {
++            mp_msg(MSGT_CPLAYER, MSGL_WARN, "Could not parse udp string!\n");
++            return -1;
++        }
++    }
++    if (chars_received == -1)
++        return -1;
++
++    return 0;
++}
++
++void send_udp(struct MPContext *mpctx, const char *send_to_ip, int port, char *mesg)
++{
++    static int sockfd = -1;
++    static struct sockaddr_in socketinfo;
++
++    if (sockfd == -1) {
++        static const int one = 1;
++        int ip_valid = 0;
++
++        startup();
++        sockfd = socket(AF_INET, SOCK_DGRAM, 0);
++        if (sockfd == -1)
++            exit_player_with_rc(mpctx, EXIT_ERROR, 1);
++
++        // Enable broadcast
++        setsockopt(sockfd, SOL_SOCKET, SO_BROADCAST, &one, sizeof(one));
++
++#if HAVE_WINSOCK2_H
++        socketinfo.sin_addr.s_addr = inet_addr(send_to_ip);
++        ip_valid = socketinfo.sin_addr.s_addr != INADDR_NONE;
++#else
++        ip_valid = inet_aton(send_to_ip, &socketinfo.sin_addr);
++#endif
++
++        if (!ip_valid) {
++            mp_msg(MSGT_CPLAYER, MSGL_FATAL, "Option -udp-ip: invalid IP address\n");
++            exit_player_with_rc(mpctx, EXIT_ERROR, 1);
++        }
++
++        socketinfo.sin_family = AF_INET;
++        socketinfo.sin_port   = htons(port);
++    }
++
++    sendto(sockfd, mesg, strlen(mesg), 0, (struct sockaddr *) &socketinfo,
++           sizeof(socketinfo));
++}
++
++// this function makes sure we stay as close as possible to the master's
++// position.  returns 1 if the master tells us to exit,
++// -1 on error and normal timing should be used again, 0 otherwise.
++int udp_slave_sync(struct MPContext *mpctx)
++{
++    // remember where the master is in the file
++    static double udp_master_position;
++    // whether we timed out before waiting for a master message
++    static int timed_out = -1;
++    // last time we received a valid master message
++    static unsigned last_success;
++    int master_exited;
++
++    if (timed_out < 0) {
++        // initialize
++        udp_master_position = mpctx->sh_video->pts - udp_seek_threshold / 2;
++        timed_out = 0;
++        last_success = GetTimerMS();
++    }
++
++    // grab any waiting datagrams without blocking
++    master_exited = get_udp(0, &udp_master_position);
++
++    while (!master_exited || (!timed_out && master_exited < 0)) {
++        double my_position = mpctx->sh_video->pts;
++
++        // if we're way off, seek to catch up
++        if (FFABS(my_position - udp_master_position) > udp_seek_threshold) {
++            queue_seek(mpctx, MPSEEK_ABSOLUTE, udp_master_position, 1);
++            break;
++        }
++
++        // normally we expect that the master will have just played the
++        // frame we're ready to play.  break out and play it, and we'll be
++        // right in sync.
++        // or, the master might be up to a few seconds ahead of us, in
++        // which case we also want to play the current frame immediately,
++        // without waiting.
++        // UDP_TIMING_TOLERANCE is a small value that lets us consider
++        // the master equal to us even if it's very slightly ahead.
++        if (udp_master_position + UDP_TIMING_TOLERANCE > my_position)
++            break;
++
++        // the remaining case is that we're slightly ahead of the master.
++        // usually, it just means we called get_udp() before the datagram
++        // arrived.  call get_udp again, but this time block until we receive
++        // a datagram.
++        master_exited = get_udp(1, &udp_master_position);
++        if (master_exited < 0)
++            timed_out = 1;
++    }
++
++    if (master_exited >= 0) {
++        last_success = GetTimerMS();
++        timed_out = 0;
++    } else {
++        master_exited = 0;
++        timed_out |= GetTimerMS() - last_success > 30000;
++    }
++
++    return timed_out ? -1 : master_exited;
++}
+diff --git a/udp_sync.h b/udp_sync.h
+new file mode 100644
+index 0000000..9a1e25a
+--- /dev/null
++++ b/udp_sync.h
+@@ -0,0 +1,38 @@
++/*
++ * Network playback synchronization
++ * Copyright (C) 2009 Google Inc.
++ *
++ * This file is part of MPlayer.
++ *
++ * MPlayer is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * MPlayer is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License along
++ * with MPlayer; if not, write to the Free Software Foundation, Inc.,
++ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
++ */
++
++#ifndef MPLAYER_UDP_SYNC_H
++#define MPLAYER_UDP_SYNC_H
++
++#include "mp_core.h"
++
++// config options for UDP sync
++extern int udp_master;
++extern int udp_slave;
++extern int udp_port;
++extern const char *udp_ip; // where the master sends datagrams
++                           // (can be a broadcast address)
++extern float udp_seek_threshold; // how far off before we seek
++
++void send_udp(struct MPContext *mpctx, const char *send_to_ip, int port, char *mesg);
++int udp_slave_sync(MPContext *mpctx);
++
++#endif /* MPLAYER_UDP_SYNC_H */
+-- 
+1.9.1
+

--- a/mplayer2-patches/0002-Fixing-udp_sync-and-associated-code-so-udp_slave-sor.patch
+++ b/mplayer2-patches/0002-Fixing-udp_sync-and-associated-code-so-udp_slave-sor.patch
@@ -1,0 +1,109 @@
+From 2e1533c565b1227eb7c6ae557dfebf93c03b70a5 Mon Sep 17 00:00:00 2001
+From: Crewmen <crewmen@sigaint.org>
+Date: Mon, 26 May 2015 05:54:58 +0000
+Subject: [PATCH 2/2] Fixing udp_sync and associated code, so udp_slave sort of
+ works.
+
+---
+ command.c  |  7 +++++++
+ mplayer.c  | 22 +++++++++++-----------
+ udp_sync.c |  7 ++++---
+ 3 files changed, 22 insertions(+), 14 deletions(-)
+
+diff --git a/command.c b/command.c
+index ae79669..ad7f5cf 100644
+--- a/command.c
++++ b/command.c
+@@ -71,6 +71,10 @@
+ #include "mp_fifo.h"
+ #include "libavutil/avstring.h"
+ 
++#ifdef CONFIG_NETWORKING
++#include "udp_sync.h"
++#endif /* CONFIG_NETWORKING */
++
+ static void rescale_input_coordinates(struct MPContext *mpctx, int ix, int iy,
+                                       double *dx, double *dy)
+ {
+@@ -2739,6 +2743,9 @@ void run_command(MPContext *mpctx, mp_cmd_t *cmd)
+         goto old_pause_hack;  // was handled already
+     switch (cmd->id) {
+     case MP_CMD_SEEK: {
++#ifdef CONFIG_NETWORKING
++        if (udp_slave) break;
++#endif /* CONFIG_NETWORKING */
+         mpctx->add_osd_seek_info = true;
+         float v = cmd->args[0].v.f;
+         int abs = (cmd->nargs > 1) ? cmd->args[1].v.i : 0;
+diff --git a/mplayer.c b/mplayer.c
+index 14ac794..a9f5042 100644
+--- a/mplayer.c
++++ b/mplayer.c
+@@ -3489,17 +3489,6 @@ static void run_playloop(struct MPContext *mpctx)
+             }
+         }
+ 
+-#ifdef CONFIG_NETWORKING
+-        if (udp_slave) {
+-            int udp_master_exited = udp_slave_sync(mpctx);
+-            if (udp_master_exited > 0) {
+-                mp_msg(MSGT_CPLAYER, MSGL_INFO, "Option -udp-slave: exiting because master exited\n");
+-                exit_player(mpctx, EXIT_QUIT);
+-            } else if (udp_master_exited == 0)
+-                goto flip_page;
+-        }
+-#endif /* CONFIG_NETWORKING */
+-
+         if (!video_left || (mpctx->paused && !mpctx->restart_playback))
+             break;
+         if (!vo->frame_loaded) {
+@@ -3760,6 +3749,17 @@ static void run_playloop(struct MPContext *mpctx)
+ 
+     current_module = "key_events";
+ 
++#ifdef CONFIG_NETWORKING
++    if (udp_slave) {
++        int udp_master_exited = udp_slave_sync(mpctx);
++        if (udp_master_exited > 0) {
++            mp_msg(MSGT_CPLAYER, MSGL_INFO,
++                   "Option -udp-slave: exiting because master exited\n");
++            exit_player(mpctx, EXIT_QUIT);
++        }
++    }
++#endif /* CONFIG_NETWORKING */
++
+     mp_cmd_t *cmd;
+     while ((cmd = mp_input_get_cmd(mpctx->input, 0, 1)) != NULL) {
+         /* Allow running consecutive seek commands to combine them,
+diff --git a/udp_sync.c b/udp_sync.c
+index 0c4a518..a366a25 100644
+--- a/udp_sync.c
++++ b/udp_sync.c
+@@ -56,7 +56,7 @@ int udp_slave  = 0;
+ int udp_port   = 23867;
+ const char *udp_ip = "127.0.0.1"; // where the master sends datagrams
+                                   // (can be a broadcast address)
+-float udp_seek_threshold = 1.0;   // how far off before we seek
++float udp_seek_threshold = 0.2;   // how far off before we seek
+ 
+ // how far off is still considered equal
+ #define UDP_TIMING_TOLERANCE 0.02
+@@ -205,12 +205,13 @@ int udp_slave_sync(struct MPContext *mpctx)
+     // grab any waiting datagrams without blocking
+     master_exited = get_udp(0, &udp_master_position);
+ 
+-    while (!master_exited || (!timed_out && master_exited < 0)) {
++    while (mpctx->sh_video->pts != MP_NOPTS_VALUE
++           && (!master_exited || (!timed_out && master_exited < 0))) {
+         double my_position = mpctx->sh_video->pts;
+ 
+         // if we're way off, seek to catch up
+         if (FFABS(my_position - udp_master_position) > udp_seek_threshold) {
+-            queue_seek(mpctx, MPSEEK_ABSOLUTE, udp_master_position, 1);
++            queue_seek(mpctx, MPSEEK_ABSOLUTE, udp_master_position, 0);
+             break;
+         }
+ 
+-- 
+1.9.1
+

--- a/vorze.c
+++ b/vorze.c
@@ -222,15 +222,11 @@ int vorzeSet(int handle, int v1, int v2) {
 
 int vorzeClose(int handle) {
 	if (!simulate) {
-		printf("\nAttempting to stop Vorze.");
-		fflush(stdout);
+		printf("\nAttempting to stop Vorze...\n");
 		vorzeSet(handle, 0, 0);
 		usleep(250000);
-		printf(".");
-		fflush(stdout);
 		vorzeSet(handle, 0, 0);
 		usleep(250000);
-		printf(".\n");
 		vorzeSet(handle, 0, 0);
 	}
 	close(handle);

--- a/vorze.c
+++ b/vorze.c
@@ -221,7 +221,17 @@ int vorzeSet(int handle, int v1, int v2) {
 }
 
 int vorzeClose(int handle) {
-	vorzeSet(handle, 0, 0);
-	if (!simulate) close(handle);
-	return;
+	if (!simulate) {
+		printf("\nAttempting to stop Vorze.");
+		fflush(stdout);
+		vorzeSet(handle, 0, 0);
+		usleep(250000);
+		printf(".");
+		fflush(stdout);
+		vorzeSet(handle, 0, 0);
+		usleep(250000);
+		printf(".\n");
+		vorzeSet(handle, 0, 0);
+	}
+	close(handle);
 }

--- a/vorze.c
+++ b/vorze.c
@@ -194,7 +194,7 @@ int vorzeSet(int handle, int v1, int v2) {
 		clock_gettime(CLOCK_MONOTONIC, &slots[i].ts);
 		buff[2]=(v1?0x80:0)|v2;
 		write(handle, buff, 3);
-		printf("V1=%d V2=%d (slot %d)\n", v1, v2, i);
+		printf("V1=%d V2=%3d (slot %d)\n", v1, v2, i);
 		needResend=0;
 	} else {
 		//We need to send this Later.

--- a/vorze.c
+++ b/vorze.c
@@ -95,9 +95,17 @@ int vorzeDetectPort(char *serport) {
 	return found;
 }
 
+//Don't actually send anything to Vorze; just write console output
+static int simulate=0;
+
+void enableSimulation() {
+	simulate=1;
+}
 
 //Open the serial port to the Vorze.
 int vorzeOpen(char *port) {
+	if (simulate) return 255;
+
 	struct termios newtio;
 	fd_set rfds;
 	struct timeval tv;
@@ -162,6 +170,8 @@ static void handleSlots() {
 }
 
 int vorzeDoResendIfNeeded(int handle) {
+	if (simulate) return;
+
 	int i, canSend=0;
 	handleSlots();
 	if (!needResend) return;
@@ -178,6 +188,13 @@ int vorzeDoResendIfNeeded(int handle) {
 }
 
 int vorzeSet(int handle, int v1, int v2) {
+	const char fmtstr[] = "V1=%d V2=%3d (slot %d)\n";
+
+	if (simulate) {
+		printf(fmtstr, v1, v2, 0);
+		return;
+	}
+
 	int i;
 	int canSend=0;
 	char buff[3]={1,1,0};
@@ -194,7 +211,7 @@ int vorzeSet(int handle, int v1, int v2) {
 		clock_gettime(CLOCK_MONOTONIC, &slots[i].ts);
 		buff[2]=(v1?0x80:0)|v2;
 		write(handle, buff, 3);
-		printf("V1=%d V2=%3d (slot %d)\n", v1, v2, i);
+		printf(fmtstr, v1, v2, i);
 		needResend=0;
 	} else {
 		//We need to send this Later.
@@ -205,6 +222,6 @@ int vorzeSet(int handle, int v1, int v2) {
 
 int vorzeClose(int handle) {
 	vorzeSet(handle, 0, 0);
-	close(handle);
+	if (!simulate) close(handle);
 	return;
 }

--- a/vorze.c
+++ b/vorze.c
@@ -91,7 +91,7 @@ int vorzeDetectPort(char *serport) {
 		globfree(&globbuf2);
 	}
 	globfree(&globbuf);
-	if (!found) printf("No Forze USB stick found.\n");
+	if (!found) printf("No Vorze USB stick found.\n");
 	return found;
 }
 

--- a/vorze.h
+++ b/vorze.h
@@ -1,6 +1,7 @@
 #ifndef VORZE_H
 #define VORZE_H
 
+void enableSimulation();
 int vorzeOpen(char *port);
 int vorzeSet(int handle, int v1, int v2);
 int vorzeClose(int handle);


### PR DESCRIPTION
(Trying again. Not the best idea to create a pull request from my main branch.)

Enhanced and cleaned up the application a bit
- Stopped it from spamming the console. No more messages about every single joystick event, and the frame counter now stays on one line until a Vorze control change. One can now much more easily see what happens when.
- Made joystick axis and buttons configurable. Reduced to one axis. Now any Linux compatible joystick device with at least a _single_ analog axis and maybe a button or two should be useable, regardless of how its mapped.
- Added switch to turn off Vorze output, for testing or other purposes.
- Added commands `playsa` and `recordsa` ("sa" = "stand-alone"), which work like `play` and `record`, but don't sync to mplayer. Instead, they use their own clock-based timing. Currently, there's no way to seek, you just have to play from beginning and let it go. ~~It also doesn't stop the Vorze if you Ctrl-C it, so that's something to be added.~~
- Patched [MPlayer2](http://repo.or.cz/mplayer.git) to port UDP sync from [MPlayer](http://mplayerhq.hu), including `-udp-master`. Also included `-udp-slave` code. That kind of works, as long as you don't do anything fancy like change the playback speed. Or pause. Resyncing is pretty much perfect if the master seeks. But mostly, Vorze users are going to want `-udp-master`, and that works great.
